### PR TITLE
Fix private inheritance from std::fstream in FileStream

### DIFF
--- a/src/utils/FileStream.h
+++ b/src/utils/FileStream.h
@@ -4,7 +4,7 @@
 #include <algorithm>
 #include <filesystem>
 
-class FileStream : std::fstream {
+class FileStream : public std::fstream {
 public:
     FileStream()
         : std::fstream()


### PR DESCRIPTION
This fix addresses a compilation error on modern compilers (e.g., Clang on macOS) where `EmbedFileStream` indirectly inherits from `std::basic_ios` with a private destructor due to non-public inheritance.

**Changes:**
- Updated `FileStream` to inherit publicly from `std::fstream` instead of defaulting to private.
- This makes the base class destructor accessible to derived classes like `EmbedFileStream`.

